### PR TITLE
Added clear routine. This way I can reuse variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Suppose you want to use a grid of size `n_grid`, then you could do:
 
     integer     :: n_grid
     type(CFG_t) :: my_cfg
-
+    
     call CFG_add(my_cfg, "grid_size", 1024, "Size of the grid")
     call CFG_read_file(my_cfg, "my_input_file.txt")
     call CFG_get(my_cfg, "grid_size", n_grid)
@@ -32,7 +32,7 @@ read the file first, and to combine the `add` and the `get`:
 
     integer     :: n_grid = 1024
     type(CFG_t) :: my_cfg
-
+    
     call CFG_read_file(my_cfg, "my_input_file.txt")
     call CFG_add_get(my_cfg, "grid_size", n_grid, "Size of the grid")
 
@@ -61,13 +61,13 @@ An example of a configuration file is shown below
 
     age = 29
     name = John
-
+    
     [weather]
         temperature = 25.2
         humidity = 23.5
-
+    
     happy = .true.
-
+    
     weather%temperature = 23.9
 
 Note that `temperature` and `humidity` are indented, and that `happy` is not,
@@ -104,6 +104,7 @@ when creating a config variable:
 * `CFG_write_markdown`: Write the configuration to a file in markdown format
 * `CFG_read_file`: Read in a configuration file
 * `CFG_update_from_arguments`: Read in the program's arguments as configuration files.
+* `CFG_clear`: Clear config for reuse
 
 ## Requirements
 

--- a/m_config.f90
+++ b/m_config.f90
@@ -112,6 +112,7 @@ module m_config
   public :: CFG_write_markdown
   public :: CFG_read_file
   public :: CFG_update_from_arguments
+  public :: CFG_clear
 
 contains
 
@@ -1177,5 +1178,16 @@ contains
        marker = left
     end if
   end subroutine parition_var_list
+  
+  subroutine CFG_clear(cfg)
+      implicit none
+      type(CFG_t)     :: cfg
+
+      cfg%sorted =  .False.
+      cfg%num_vars =  0
+      if(allocated(cfg%vars)) then
+          deallocate(cfg%vars)
+      endif
+    end subroutine CFG_clear
 
 end module m_config


### PR DESCRIPTION
I am using a single CFG_T variable to iterate through multiple config-files. If I perform 

`CFG_add(cfg, "bla%x", 1, "")
CFG_add(cfg, "bla%x", 2, "")
`
the second throws an error, because "bla%x" already exists. With the new routine one can do:
`CFG_add(cfg, "bla%x", 1, "")
CFG_clear(cfg)
CFG_add(cfg, "bla%x", 2, "")
`