### PR TITLE
';' seems to be the standard for ini-file comments

### DIFF
--- a/m_config.f90
+++ b/m_config.f90
@@ -187,6 +187,7 @@ contains
        line_number = line_number + 1
 
        call trim_comment(line, '#')
+       call trim_comment(line, ';')
 
        ! Skip empty lines
        if (line == "") cycle
@@ -315,7 +316,7 @@ contains
        end select
        if(stat /= 0) then
           write (*,"(A,I3,A)") "Error ", stat, " when reading:"
-          write (*,*) var%stored_data(ix_start(n):ix_end(n)) 
+          write (*,*) var%stored_data(ix_start(n):ix_end(n))
           stop
        endif
     end do


### PR DESCRIPTION
This library uses `#` for comments, but it seems the standard is to use `;`:
https://en.wikipedia.org/wiki/INI_file
Adding this to the code will improve interoperability (e.g. with pythons config library).

I didn't change it for the output files, because it might break someone elses code, but it certainly is worth a consideration.