### PR TITLE
Update m_config.f90

### DIFF
--- a/m_config.f90
+++ b/m_config.f90
@@ -22,7 +22,7 @@ module m_config
   integer, parameter :: CFG_string_len = 200 !< Fixed length of string type
 
   !> Maximum number of entries in a variable (if it's an array)
-  integer, parameter :: CFG_max_array_size = 20
+  integer, parameter :: CFG_max_array_size = 1000
 
   !> The separator(s) for array-like variables (space, comma, ', ", and tab)
   character(len=*), parameter :: CFG_separators = " ,'"""//char(9)


### PR DESCRIPTION
This maximum array size seems somewhat small and arbitrary. 
I fell that 20 values fit easily in a line and if more are added into a line, the library reads the first 20 and then discards the rest.
 
The question is whether it's needed at all. The function `get_fields_string` could just grow arrays with fortrans "new" array operator:

```fortran
ix = [ix, new_element]
```