### PR TITLE
Better formating for real numbers

### DIFF
--- a/m_config.f90
+++ b/m_config.f90
@@ -470,7 +470,7 @@ contains
           end do
        case (CFG_real_type)
           do j = 1, cfg%vars(i)%var_size
-             write(myUnit, ADVANCE="NO", ERR=998, FMT="(A,E11.4)") &
+             write(myUnit, ADVANCE="NO", ERR=998, FMT="(A,ES11.4)") &
                   " ", cfg%vars(i)%real_data(j)
           end do
        case (CFG_string_type)


### PR DESCRIPTION
I know this is mostly aesthetic, but I believe `1` written as

`0.1000E1`

is less clear than

`1.000E0`